### PR TITLE
fix: sidebar overflow

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     "description": "Adds a thin configurable banner to the Shopware Administration.",
     "type": "shopware-platform-plugin",
     "license": "MIT",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "require": {
         "shopware/core": ">=6.7.0 <6.8.0"
     },

--- a/src/Resources/app/administration/src/component/fewiel-admin-banner/fewiel-admin-banner.html.twig
+++ b/src/Resources/app/administration/src/component/fewiel-admin-banner/fewiel-admin-banner.html.twig
@@ -1,5 +1,6 @@
 {% block fewiel_admin_banner %}
     <div class="fewiel-admin-banner"
+         v-if="showBanner"
          :style="bannerStyle">
         <span class="fewiel-admin-banner__text">{{ bannerText }}</span>
     </div>

--- a/src/Resources/app/administration/src/component/fewiel-admin-banner/fewiel-admin-banner.scss
+++ b/src/Resources/app/administration/src/component/fewiel-admin-banner/fewiel-admin-banner.scss
@@ -23,5 +23,3 @@
     max-width: 100%;
     text-align: center;
 }
-
-bo

--- a/src/Resources/app/administration/src/component/fewiel-admin-banner/fewiel-admin-banner.scss
+++ b/src/Resources/app/administration/src/component/fewiel-admin-banner/fewiel-admin-banner.scss
@@ -8,7 +8,7 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    z-index: 10000;
+    z-index: 1000;
     padding: 4px 12px;
     box-sizing: border-box;
 }
@@ -23,3 +23,5 @@
     max-width: 100%;
     text-align: center;
 }
+
+bo

--- a/src/Resources/app/administration/src/extension/sw-desktop/index.js
+++ b/src/Resources/app/administration/src/extension/sw-desktop/index.js
@@ -1,8 +1,8 @@
-import template from './sw-admin.html.twig';
+import template from './sw-desktop.html.twig';
 
 // Ensure the banner component is registered
 import '../../component/fewiel-admin-banner';
 
-Shopware.Component.override('sw-admin', {
+Shopware.Component.override('sw-desktop', {
     template,
 });

--- a/src/Resources/app/administration/src/extension/sw-desktop/sw-desktop.html.twig
+++ b/src/Resources/app/administration/src/extension/sw-desktop/sw-desktop.html.twig
@@ -1,4 +1,4 @@
-{% block sw_admin %}
+{% block sw_desktop_content_view %}
     <fewiel-admin-banner />
     {% parent %}
 {% endblock %}


### PR DESCRIPTION
This PR fixes a few issues:
 - banner was visible on top of the modal - now it's displayed in the background
 - it was rendered in `sw-admin:root`, made full-width, pushing the whole sidebar below the visible screen (making logout button partially invisible) - now it's rendered in the `sw-desktop:sw_desktop_content_view`

<img width="1631" height="353" alt="image" src="https://github.com/user-attachments/assets/dc5af24c-bbed-44fa-a492-ec88d1500cf7" />
